### PR TITLE
Service section layout improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
   <section class="services layout-container" id="services-terminal">
     <h2>sys\terminal[services]</h2>
     <div class="service-list">
-      <button class="service" data-img="./assets/images/noise.gif" data-title="fine art comissions / digital art" data-desc="sketches; custom art pieces; poster design; sigils; tattoo flashes; nft projects;">
+      <div class="service" data-img="./assets/images/noise.gif" data-title="fine art comissions / digital art" data-desc="sketches; custom art pieces; poster design; sigils; tattoo flashes; nft projects;">
         <h3>fine art comissions / digital art ↘</h3>
         <p>sketches; custom art pieces; poster design; sigils; tattoo flashes; nft projects;</p>
         <div class="service-details">
@@ -133,8 +133,8 @@
           <div class="service-text"></div>
           <button class="stack-btn">stack&gt; <span class="cart-count">0</span> items in memory</button>
         </div>
-      </button>
-      <button class="service" data-img="./assets/images/noise.gif" data-title="publication design / conceptual writing" data-desc="zines; book layouts; typographic experiments; speculative essays; visual philosophy;">
+      </div>
+      <div class="service" data-img="./assets/images/noise.gif" data-title="publication design / conceptual writing" data-desc="zines; book layouts; typographic experiments; speculative essays; visual philosophy;">
         <h3>publication design / conceptual writing ↘</h3>
         <p>zines; book layouts; typographic experiments; speculative essays; visual philosophy;</p>
         <div class="service-details">
@@ -142,8 +142,8 @@
           <div class="service-text"></div>
           <button class="stack-btn">stack&gt; <span class="cart-count">0</span> items in memory</button>
         </div>
-      </button>
-      <button class="service" data-img="./assets/images/noise.gif" data-title="graphic design / screen design" data-desc="modular identities; product packagings; ux/ui; letterforms; visual communication strategies">
+      </div>
+      <div class="service" data-img="./assets/images/noise.gif" data-title="graphic design / screen design" data-desc="modular identities; product packagings; ux/ui; letterforms; visual communication strategies">
         <h3>graphic design / screen design ↘</h3>
         <p>modular identities; product packagings; ux/ui; letterforms; visual communication strategies</p>
         <div class="service-details">
@@ -151,8 +151,8 @@
           <div class="service-text"></div>
           <button class="stack-btn">stack&gt; <span class="cart-count">0</span> items in memory</button>
         </div>
-      </button>
-      <button class="service" data-img="./assets/images/noise.gif" data-title="producing / experimental sound design" data-desc="soundscapes; idm / triphop / noise / ambient; conceptual audio; voiceover; mixing & mastering">
+      </div>
+      <div class="service" data-img="./assets/images/noise.gif" data-title="producing / experimental sound design" data-desc="soundscapes; idm / triphop / noise / ambient; conceptual audio; voiceover; mixing & mastering">
         <h3>producing / experimental sound design ↘</h3>
         <p>soundscapes; idm / triphop / noise / ambient; conceptual audio; voiceover; mixing & mastering</p>
         <div class="service-details">
@@ -160,7 +160,7 @@
           <div class="service-text"></div>
           <button class="stack-btn">stack&gt; <span class="cart-count">0</span> items in memory</button>
         </div>
-      </button>
+      </div>
     </div>
     <p class="rate">standard rate: 42€/h<br>we're open to resonance-based adjustments_</p>
   </section>

--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
   <section class="services layout-container" id="services-terminal">
     <h2>sys\terminal[services]</h2>
     <div class="service-list">
-      <button class="service" data-img="" data-title="fine art comissions / digital art" data-desc="sketches; custom art pieces; poster design; sigils; tattoo flashes; nft projects;">
+      <button class="service" data-img="./assets/images/noise.gif" data-title="fine art comissions / digital art" data-desc="sketches; custom art pieces; poster design; sigils; tattoo flashes; nft projects;">
         <h3>fine art comissions / digital art ↘</h3>
         <p>sketches; custom art pieces; poster design; sigils; tattoo flashes; nft projects;</p>
         <div class="service-details">
@@ -134,7 +134,7 @@
           <button class="stack-btn">stack&gt; <span class="cart-count">0</span> items in memory</button>
         </div>
       </button>
-      <button class="service" data-img="" data-title="publication design / conceptual writing" data-desc="zines; book layouts; typographic experiments; speculative essays; visual philosophy;">
+      <button class="service" data-img="./assets/images/noise.gif" data-title="publication design / conceptual writing" data-desc="zines; book layouts; typographic experiments; speculative essays; visual philosophy;">
         <h3>publication design / conceptual writing ↘</h3>
         <p>zines; book layouts; typographic experiments; speculative essays; visual philosophy;</p>
         <div class="service-details">
@@ -143,7 +143,7 @@
           <button class="stack-btn">stack&gt; <span class="cart-count">0</span> items in memory</button>
         </div>
       </button>
-      <button class="service" data-img="" data-title="graphic design / screen design" data-desc="modular identities; product packagings; ux/ui; letterforms; visual communication strategies">
+      <button class="service" data-img="./assets/images/noise.gif" data-title="graphic design / screen design" data-desc="modular identities; product packagings; ux/ui; letterforms; visual communication strategies">
         <h3>graphic design / screen design ↘</h3>
         <p>modular identities; product packagings; ux/ui; letterforms; visual communication strategies</p>
         <div class="service-details">
@@ -152,7 +152,7 @@
           <button class="stack-btn">stack&gt; <span class="cart-count">0</span> items in memory</button>
         </div>
       </button>
-      <button class="service" data-img="" data-title="producing / experimental sound design" data-desc="soundscapes; idm / triphop / noise / ambient; conceptual audio; voiceover; mixing & mastering">
+      <button class="service" data-img="./assets/images/noise.gif" data-title="producing / experimental sound design" data-desc="soundscapes; idm / triphop / noise / ambient; conceptual audio; voiceover; mixing & mastering">
         <h3>producing / experimental sound design ↘</h3>
         <p>soundscapes; idm / triphop / noise / ambient; conceptual audio; voiceover; mixing & mastering</p>
         <div class="service-details">

--- a/script.js
+++ b/script.js
@@ -150,6 +150,11 @@ serviceButtons.forEach(btn => {
     const text = btn.dataset.desc;
     const container = btn.querySelector('.service-text');
     if (container) container.textContent = text || '';
+    const imgEl = btn.querySelector('img');
+    if (imgEl && btn.dataset.img) {
+      imgEl.src = btn.dataset.img;
+      imgEl.alt = btn.dataset.title || '';
+    }
   });
 });
 

--- a/style.css
+++ b/style.css
@@ -441,6 +441,7 @@ header {
 }
 
 .service {
+  position: relative;
   padding: 1rem;
   border: none;
   background-color: #111;
@@ -457,20 +458,26 @@ header {
   margin-top: 1rem;
   gap: 20px;
   align-items: flex-start;
+  position: relative;
+  padding-bottom: 40px;
 }
 .service.open .service-details {
   display: flex;
+  flex-direction: row-reverse;
 }
 .service-details img {
-  width: 40%;
+  width: 50%;
   height: auto;
 }
 .service-text {
-  flex: 1;
+  width: 50%;
   color: #ccc;
 }
 .stack-btn {
-  margin-top: 1rem;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  margin-top: 0;
   background: none;
   border: 1px solid #888;
   color: #fff;

--- a/style.css
+++ b/style.css
@@ -443,7 +443,7 @@ header {
 .service {
   position: relative;
   padding: 1rem;
-  border: none;
+  border: 1px solid #333;
   background-color: #111;
   cursor: pointer;
   text-align: left;
@@ -475,8 +475,8 @@ header {
 }
 .stack-btn {
   position: absolute;
-  bottom: 0;
-  right: 0;
+  bottom: 10px;
+  right: 10px;
   margin-top: 0;
   background: none;
   border: 1px solid #888;


### PR DESCRIPTION
## Summary
- include local image path for each service item
- position stack buttons inside expanded services
- load service images dynamically
- tweak service layout for side-by-side image and text

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ea68e3c7c832a9c10825e8770b0ad