### PR TITLE
Update hero with shader background

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,9 +25,9 @@
   </header>
 
 <section class="hero">
+  <canvas id="hero-canvas"></canvas>
   <div class="layout-container hero-inner">
     <div class="hero-left">
-      <img src="./assets/images/noise.gif" alt="noise" class="noise-img">
       <p class="participate-note">^you are already participating</p>
     </div>
     <div class="studio-info">
@@ -45,7 +45,8 @@
   </div>
 </section>
 
- <section class="shop-section layout-container">
+ <section class="shop-section">
+  <div class="layout-container">
   <h2>&gt;&gt; run /modules</h2>
     <div class="filters">
       <span class="filter-label">filter >></span>
@@ -119,6 +120,7 @@
       <ul class="product-list"></ul>
     </div>
   </div>
+</div>
 </section>
 
 

--- a/style.css
+++ b/style.css
@@ -122,14 +122,6 @@ header {
   z-index: 1;
 }
 
-.noise-img {
-  width: 100%;
-  max-width: none;
-  height: auto;
-  aspect-ratio: 1100 / 666;
-  object-fit: cover;
-  display: block;
-}
 
 #hero-canvas {
   position: absolute;

--- a/style.css
+++ b/style.css
@@ -101,6 +101,7 @@ header {
   display: flex;
   justify-content: center;
   position: relative;
+  overflow: hidden;
 }
 
 .hero-inner {
@@ -117,6 +118,8 @@ header {
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  position: relative;
+  z-index: 1;
 }
 
 .noise-img {
@@ -126,6 +129,17 @@ header {
   aspect-ratio: 1100 / 666;
   object-fit: cover;
   display: block;
+}
+
+#hero-canvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100%;
+  display: block;
+  pointer-events: none;
+  z-index: 0;
 }
 
 .participate-note {
@@ -149,6 +163,8 @@ header {
   color: #ccc;
   line-height: 1.6;
   white-space: nowrap;
+  position: relative;
+  z-index: 1;
 }
 
 @media (max-width: 800px) {
@@ -184,9 +200,26 @@ header {
 
 /* SHOP SECTION */
 .shop-section {
-  border-top: 1px solid #fff;
-  border-bottom: 1px solid #fff;
+  position: relative;
   padding: 60px 0;
+}
+
+.shop-section::before,
+.shop-section::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 100vw;
+  height: 1px;
+  background: #fff;
+}
+
+.shop-section::before {
+  top: 0;
+}
+
+.shop-section::after {
+  bottom: 0;
 }
 
 .shop-section h2 {


### PR DESCRIPTION
## Summary
- swap hero GIF for animated WebGL canvas
- keep hero content above canvas
- widen horizontal lines around `>> run /modules`
- add fragment shader and canvas driver

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6860f927cc40832aab32359ea29134a1