### PR TITLE
Align hero text blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 
 <section class="hero">
   <canvas id="hero-canvas"></canvas>
-  <div class="hero-inner">
+  <div class="layout-container hero-inner">
     <div class="studio-info">
       <p>> self-replication detected</p>
       <p>> nochoicehavefun initialized</p>
@@ -44,6 +44,7 @@
 </section>
 
  <section class="shop-section" id="modules">
+  <div class="layout-container">
   <h2>&gt;&gt; run /modules</h2>
     <div class="filters">
       <span class="filter-label">filter >></span>
@@ -117,6 +118,7 @@
       <ul class="product-list"></ul>
     </div>
   </div>
+  </div>
  </section>
 
 
@@ -182,7 +184,7 @@
   </section>
 
   <footer>
-    <div class="footer-grid">
+    <div class="layout-container footer-grid">
       <div class="footer-brand">no choice, have fun
         <p class="copyright">© 2033 by nochoicehavefun</p>
       </div>

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 
 <section class="hero">
   <canvas id="hero-canvas"></canvas>
-  <div class="layout-container hero-inner">
+  <div class="hero-inner">
     <div class="studio-info">
       <p>> self-replication detected</p>
       <p>> nochoicehavefun initialized</p>
@@ -43,8 +43,7 @@
   </div>
 </section>
 
- <section class="shop-section">
-  <div class="layout-container">
+ <section class="shop-section" id="modules">
   <h2>&gt;&gt; run /modules</h2>
     <div class="filters">
       <span class="filter-label">filter >></span>
@@ -118,8 +117,7 @@
       <ul class="product-list"></ul>
     </div>
   </div>
-</div>
-</section>
+ </section>
 
 
   <section class="services layout-container" id="services-terminal">
@@ -184,7 +182,7 @@
   </section>
 
   <footer>
-    <div class="layout-container footer-grid">
+    <div class="footer-grid">
       <div class="footer-brand">no choice, have fun
         <p class="copyright">© 2033 by nochoicehavefun</p>
       </div>

--- a/index.html
+++ b/index.html
@@ -27,9 +27,6 @@
 <section class="hero">
   <canvas id="hero-canvas"></canvas>
   <div class="layout-container hero-inner">
-    <div class="hero-left">
-      <p class="participate-note">^you are already participating</p>
-    </div>
     <div class="studio-info">
       <p>> self-replication detected</p>
       <p>> nochoicehavefun initialized</p>
@@ -39,6 +36,7 @@
       <p>> input: external stimuli</p>
       <p>> output: structured hallucination</p>
     </div>
+    <p class="participate-note">^you are already participating</p>
   </div>
   <div class="logo-fixed">
     <img src="./assets/images/logo.png" alt="logo" />

--- a/style.css
+++ b/style.css
@@ -31,7 +31,7 @@ header {
   top: 0;
   background: #000;
   z-index: 100;
-  padding: 1rem 0;
+  padding: 0.5rem 0;
   border-bottom: 1px solid #333;
 }
 
@@ -40,7 +40,7 @@ header {
   grid-template-columns: repeat(12, 1fr);
   align-items: center;
   font-size: 12px;
-  padding: 1rem 0;
+  padding: 0.5rem 0;
 }
 
 .nav-bar a {
@@ -108,9 +108,7 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  max-width: 1440px;
-  margin: 0 auto;
-  padding: 80px 160px 60px;
+  padding: 80px 0 60px;
 }
 
 
@@ -154,7 +152,7 @@ header {
 @media (max-width: 800px) {
   .hero-inner {
     flex-direction: column;
-    padding: 60px 20px;
+    padding: 60px 0;
   }
   .studio-info {
     font-size: clamp(12px, 3vw, 14px);
@@ -163,10 +161,6 @@ header {
   }
   .participate-note {
     align-self: flex-end;
-  }
-  .shop-section {
-    padding-left: 20px;
-    padding-right: 20px;
   }
 }
 
@@ -188,7 +182,7 @@ header {
 /* SHOP SECTION */
 .shop-section {
   position: relative;
-  padding: 60px 160px;
+  padding: 60px 0;
 }
 
 .shop-section::before,
@@ -607,9 +601,6 @@ footer {
   flex-wrap: wrap;
   gap: 2rem;
   align-items: flex-end;
-  max-width: 1440px;
-  margin: 0 auto;
-  padding: 0 160px;
 }
 
 .footer-links a {
@@ -627,11 +618,6 @@ footer {
   flex-direction: column;
 }
 
-@media (max-width: 800px) {
-  .footer-grid {
-    padding: 0 20px;
-  }
-}
 .copyright {
   font-size: 12px;
   color: #888;

--- a/style.css
+++ b/style.css
@@ -108,8 +108,9 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  padding-top: 80px;
-  padding-bottom: 60px;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 80px 160px 60px;
 }
 
 
@@ -153,7 +154,7 @@ header {
 @media (max-width: 800px) {
   .hero-inner {
     flex-direction: column;
-    padding: 60px 0;
+    padding: 60px 20px;
   }
   .studio-info {
     font-size: clamp(12px, 3vw, 14px);
@@ -162,6 +163,10 @@ header {
   }
   .participate-note {
     align-self: flex-end;
+  }
+  .shop-section {
+    padding-left: 20px;
+    padding-right: 20px;
   }
 }
 
@@ -183,7 +188,7 @@ header {
 /* SHOP SECTION */
 .shop-section {
   position: relative;
-  padding: 60px 0;
+  padding: 60px 160px;
 }
 
 .shop-section::before,
@@ -602,6 +607,9 @@ footer {
   flex-wrap: wrap;
   gap: 2rem;
   align-items: flex-end;
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 0 160px;
 }
 
 .footer-links a {
@@ -617,6 +625,12 @@ footer {
   color: #f0f0f0;
   display: flex;
   flex-direction: column;
+}
+
+@media (max-width: 800px) {
+  .footer-grid {
+    padding: 0 20px;
+  }
 }
 .copyright {
   font-size: 12px;

--- a/style.css
+++ b/style.css
@@ -105,21 +105,11 @@ header {
 }
 
 .hero-inner {
-  display: grid;
-  grid-template-columns: repeat(12, 1fr);
-  column-gap: 20px;
-  align-items: end;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
   padding-top: 80px;
   padding-bottom: 60px;
-}
-
-.hero-left {
-  grid-column: 1 / 9;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  position: relative;
-  z-index: 1;
 }
 
 
@@ -138,8 +128,9 @@ header {
   margin-top: 20px;
   font-size: 24px;
   color: #fff;
-  text-align: left;
-  align-self: flex-start;
+  text-align: right;
+  align-self: flex-end;
+  margin-left: auto;
   max-width: 8ch;
 }
 
@@ -148,7 +139,6 @@ header {
 }
 
 .studio-info {
-  grid-column: 9 / 13;
   align-self: flex-end;
   font-family: 'Red Hat Mono', monospace;
   font-size: 14px;
@@ -157,21 +147,21 @@ header {
   white-space: nowrap;
   position: relative;
   z-index: 1;
+  max-width: 60%;
 }
 
 @media (max-width: 800px) {
   .hero-inner {
-    grid-template-columns: 1fr;
+    flex-direction: column;
     padding: 60px 0;
   }
-  .hero-left {
-    grid-column: 1 / -1;
-  }
   .studio-info {
-    grid-column: 1 / -1;
     font-size: clamp(12px, 3vw, 14px);
-    margin-top: 20px;
+    margin-bottom: 20px;
     align-self: flex-start;
+  }
+  .participate-note {
+    align-self: flex-end;
   }
 }
 
@@ -635,9 +625,3 @@ footer {
 }
 
 /* DEBUG OUTLINES */
-.hero-inner > *,
-.product-grid > *,
-.nav-bar > *,
-.footer-grid > * {
-  outline: 1px dashed rgba(255, 255, 255, 0.1);
-}


### PR DESCRIPTION
## Summary
- restructure hero section layout so both text blocks use the common container width
- place `^you are already participating` on the right and remove debug outlines
- tidy CSS and responsive rules

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686108c2f574832a9ed290ea11ac8546