### PR TITLE
Fix hero canvas and shop line widths

### DIFF
--- a/style.css
+++ b/style.css
@@ -116,7 +116,7 @@ header {
   position: absolute;
   top: 0;
   left: 0;
-  width: 100vw;
+  width: 100%;
   height: 100%;
   display: block;
   pointer-events: none;
@@ -190,7 +190,7 @@ header {
   content: "";
   position: absolute;
   left: 0;
-  width: 100vw;
+  width: 100%;
   height: 1px;
   background: #fff;
 }


### PR DESCRIPTION
## Summary
- avoid horizontal scrolling by limiting hero canvas width
- use percent width on shop section separators

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686115510b38832ab48fe4ce019d1589