### PR TITLE
Refine hero layout and unify section padding

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,17 +26,21 @@
 
 <section class="hero">
   <canvas id="hero-canvas"></canvas>
-  <div class="layout-container hero-inner">
-    <div class="studio-info">
-      <p>> self-replication detected</p>
-      <p>> nochoicehavefun initialized</p>
-      <p>> type: hybrid studio<br>&nbsp;&nbsp;\ philosophical system</p>
-      <p>> core modules: visual forms<br>&nbsp;&nbsp;\ sonic rhythms \ semiotic design</p>
-      <p>> operating logic:<br>&nbsp;&nbsp;\ cause-driven composition</p>
-      <p>> input: external stimuli</p>
-      <p>> output: structured hallucination</p>
+  <div class="hero-layout">
+    <div class="left-block">
+      <div class="terminal-box">
+        <p>> self-replication detected</p>
+        <p>> nochoicehavefun initialized</p>
+        <p>> type: hybrid studio<br>&nbsp;&nbsp;\ philosophical system</p>
+        <p>> core modules: visual forms<br>&nbsp;&nbsp;\ sonic rhythms \ semiotic design</p>
+        <p>> operating logic:<br>&nbsp;&nbsp;\ cause-driven composition</p>
+        <p>> input: external stimuli</p>
+        <p>> output: structured hallucination</p>
+      </div>
     </div>
-    <p class="participate-note">^you are already participating</p>
+    <div class="right-block">
+      <p class="tagline">^you are<br>already participating</p>
+    </div>
   </div>
   <div class="logo-fixed">
     <img src="./assets/images/logo.png" alt="logo" />

--- a/style.css
+++ b/style.css
@@ -32,7 +32,7 @@ header {
   background: #000;
   z-index: 100;
   padding: 0.5rem 0;
-  border-bottom: 1px solid #333;
+  border-bottom: 1px solid #fff;
 }
 
 .nav-bar {
@@ -106,6 +106,8 @@ header {
 
 
 .hero-layout {
+  position: relative;
+  z-index: 1;
   display: flex;
   justify-content: space-between;
   align-items: flex-end;

--- a/style.css
+++ b/style.css
@@ -16,12 +16,12 @@ body {
 .layout-container {
   max-width: 1440px;
   margin: 0 auto;
-  padding: 0 160px;
+  padding: 0 5vw;
 }
 
 @media (max-width: 800px) {
   .layout-container {
-    padding: 0 20px;
+    padding: 0 5vw;
   }
 }
 
@@ -97,18 +97,19 @@ header {
 
 /* HERO SECTION */
 .hero {
-  padding: 100px 0 60px;
+  padding: 100px 5vw 60px;
   display: flex;
   justify-content: center;
   position: relative;
   overflow: hidden;
 }
 
-.hero-inner {
+
+.hero-layout {
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  padding: 80px 0 60px;
+  padding: 0 5vw;
 }
 
 
@@ -123,44 +124,24 @@ header {
   z-index: 0;
 }
 
-.participate-note {
-  margin-top: 20px;
-  font-size: 24px;
-  color: #fff;
+
+.terminal-box {
+  background-color: rgba(0, 0, 0, 0.42);
+  border: 1px solid white;
+  padding: 1rem;
+  white-space: pre-line;
+}
+
+.tagline {
+  white-space: pre-line;
   text-align: right;
-  align-self: flex-end;
-  margin-left: auto;
-  max-width: 8ch;
-}
-
-.studio-info p {
-  white-space: nowrap;
-}
-
-.studio-info {
-  align-self: flex-end;
-  font-family: 'Red Hat Mono', monospace;
-  font-size: 14px;
-  color: #ccc;
-  line-height: 1.6;
-  white-space: nowrap;
-  position: relative;
-  z-index: 1;
-  max-width: 60%;
+  margin: 0;
 }
 
 @media (max-width: 800px) {
-  .hero-inner {
+  .hero-layout {
     flex-direction: column;
     padding: 60px 0;
-  }
-  .studio-info {
-    font-size: clamp(12px, 3vw, 14px);
-    margin-bottom: 20px;
-    align-self: flex-start;
-  }
-  .participate-note {
-    align-self: flex-end;
   }
 }
 
@@ -182,7 +163,7 @@ header {
 /* SHOP SECTION */
 .shop-section {
   position: relative;
-  padding: 60px 0;
+  padding: 60px 5vw;
 }
 
 .shop-section::before,
@@ -448,7 +429,7 @@ header {
 
 /* SERVICES SECTION */
 .services {
-  padding: 2rem 0;
+  padding: 2rem 5vw;
 }
 
 .services h2 {
@@ -590,7 +571,7 @@ header {
 
 /* FOOTER */
 footer {
-  padding: 3rem 0 5rem;
+  padding: 3rem 5vw 5rem;
   font-size: 13px;
   color: #666;
 }


### PR DESCRIPTION
## Summary
- redesign hero section with left terminal box and right tagline
- add hero-layout flexbox and terminal-box styling
- remove old hero-inner styling
- unify horizontal padding across sections

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68611b9ad884832a8e6890fd35c3e174