### PR TITLE
Fix hero layout alignment and adjust text style

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
 
 <section class="hero">
   <canvas id="hero-canvas"></canvas>
-  <div class="hero-layout">
+  <div class="hero-layout layout-container">
     <div class="left-block">
       <div class="terminal-box">
         <p>> self-replication detected</p>

--- a/index.html
+++ b/index.html
@@ -9,8 +9,8 @@
 </head>
 
 <body>
-  <header class="sticky-header">
-    <div class="layout-container nav-bar">
+  <header class="sticky-header layout-container">
+    <div class="nav-bar">
       <span class="path">&gt;&gt; ./nochoicehavefun</span>
       <a href="#services-terminal" class="connect-anchor">connect us</a>
       <div class="lang-container">

--- a/style.css
+++ b/style.css
@@ -41,6 +41,7 @@ header {
   align-items: center;
   font-size: 12px;
   padding: 0.5rem 0;
+  width: 100%;
 }
 
 .nav-bar a {
@@ -111,6 +112,11 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
+  width: 100%;
+}
+.left-block,
+.right-block {
+  flex: 1;
 }
 
 
@@ -527,6 +533,7 @@ header {
   display: flex;
   gap: 2rem;
   flex-wrap: wrap;
+  width: 100%;
 }
 
 .contact-info,

--- a/style.css
+++ b/style.css
@@ -111,7 +111,6 @@ header {
   display: flex;
   justify-content: space-between;
   align-items: flex-end;
-  padding: 0 5vw;
 }
 
 
@@ -132,6 +131,10 @@ header {
   border: 1px solid white;
   padding: 1rem;
   white-space: pre-line;
+}
+.terminal-box p {
+  line-height: 1.42;
+  letter-spacing: 0;
 }
 
 .tagline {
@@ -534,6 +537,8 @@ header {
 .contact-info p {
   font-size: 13px;
   margin-bottom: 0.5rem;
+  line-height: 1.42;
+  letter-spacing: 0;
 }
 
 .contact-form {
@@ -551,6 +556,7 @@ header {
   color: #fff;
   font-family: inherit;
   font-size: 13px;
+  letter-spacing: 0;
 }
 
 .contact-form button {
@@ -576,6 +582,8 @@ footer {
   padding: 3rem 5vw 5rem;
   font-size: 13px;
   color: #666;
+  line-height: 1.42;
+  letter-spacing: 0;
 }
 
 .footer-grid {

--- a/style.css
+++ b/style.css
@@ -97,7 +97,7 @@ header {
 
 /* HERO SECTION */
 .hero {
-  padding: 100px 5vw 60px;
+  padding: 100px 0 60px;
   display: flex;
   justify-content: center;
   position: relative;
@@ -168,7 +168,7 @@ header {
 /* SHOP SECTION */
 .shop-section {
   position: relative;
-  padding: 60px 5vw;
+  padding: 60px 0;
 }
 
 .shop-section::before,
@@ -434,7 +434,7 @@ header {
 
 /* SERVICES SECTION */
 .services {
-  padding: 2rem 5vw;
+  padding: 2rem 0;
 }
 
 .services h2 {
@@ -579,7 +579,7 @@ header {
 
 /* FOOTER */
 footer {
-  padding: 3rem 5vw 5rem;
+  padding: 3rem 0 5rem;
   font-size: 13px;
   color: #666;
   line-height: 1.42;


### PR DESCRIPTION
## Summary
- align hero section with other sections using layout container
- tweak hero layout styles for consistent padding
- fine-tune typography in the terminal, contact and footer areas

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686124a52d78832aaacdbecd202fc756